### PR TITLE
Added comma to list of allowed symbols in a command.

### DIFF
--- a/dragonfly/grammar/elements_compound.py
+++ b/dragonfly/grammar/elements_compound.py
@@ -188,7 +188,7 @@ class _Literal(parser_.Sequence):
     def __init__(self):
         # Use a pattern to allow ascii and Unicode alphanumeric characters plus a
         # few special characters.
-        pattern = re.compile(r"[\w_\-.']", re.UNICODE)
+        pattern = re.compile(r"[\w_\-.',]", re.UNICODE)
         word = parser_.CharacterSeries(None, pattern=pattern)
         whitespace = parser_.Whitespace()
         elements = (


### PR DESCRIPTION
This works as expected if used as a literal, and is the only way to have the word 'comma' present in a command and recognized properly by Dragon, as far as I can tell.