### PR TITLE
Windows Unicode keyboard support.

### DIFF
--- a/dragonfly/actions/action_text.py
+++ b/dragonfly/actions/action_text.py
@@ -3,109 +3,134 @@
 # (c) Copyright 2007, 2008 by Christo Butcher
 # Licensed under the LGPL.
 #
-#   Dragonfly is free software: you can redistribute it and/or modify it 
-#   under the terms of the GNU Lesser General Public License as published 
-#   by the Free Software Foundation, either version 3 of the License, or 
+#   Dragonfly is free software: you can redistribute it and/or modify it
+#   under the terms of the GNU Lesser General Public License as published
+#   by the Free Software Foundation, either version 3 of the License, or
 #   (at your option) any later version.
 #
-#   Dragonfly is distributed in the hope that it will be useful, but 
-#   WITHOUT ANY WARRANTY; without even the implied warranty of 
-#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU 
+#   Dragonfly is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 #   Lesser General Public License for more details.
 #
-#   You should have received a copy of the GNU Lesser General Public 
-#   License along with Dragonfly.  If not, see 
+#   You should have received a copy of the GNU Lesser General Public
+#   License along with Dragonfly.  If not, see
 #   <http://www.gnu.org/licenses/>.
 #
-
 """
 Text action
 ============================================================================
 
-This section describes the :class:`Text` action object. This type of 
+This section describes the :class:`Text` action object. This type of
 action is used for typing text into the foreground application.
 
-It differs from the :class:`Key` action in that :class:`Text` is used for 
-typing literal text, while :class:`dragonfly.actions.action_key.Key` 
-emulates pressing keys on the keyboard.  An example of this is that the 
-arrow-keys are not part of a text and so cannot be typed using the 
-:class:`Text` action, but can be sent by the 
+It differs from the :class:`Key` action in that :class:`Text` is used for
+typing literal text, while :class:`dragonfly.actions.action_key.Key`
+emulates pressing keys on the keyboard.  An example of this is that the
+arrow-keys are not part of a text and so cannot be typed using the
+:class:`Text` action, but can be sent by the
 :class:`dragonfly.actions.action_key.Key` action.
 
 """
 
+from ..engines import get_engine
+from ..windows.clipboard import Clipboard
+from .action_base import ActionError, DynStrActionBase
+from .action_key import Key
+from .keyboard import Keyboard
+from .typeables import typeables
+from six import text_type
 
-from .action_base           import DynStrActionBase, ActionError
-from .typeables             import typeables
-from .keyboard              import Keyboard
-from .action_key            import Key
-from ..windows.clipboard    import Clipboard
-from ..engines              import get_engine
+# ---------------------------------------------------------------------------
+
+USE_UNICODE = True
 
 
-#---------------------------------------------------------------------------
+def require_hardware_emulation():
+    """Return `True` if the current context requires hardware emulation."""
+    global USE_UNICODE
+    return not USE_UNICODE
+
 
 class Text(DynStrActionBase):
     """
-        Action that sends keyboard events to type text.
+    `Action` that sends keyboard events to type text.
 
-        Arguments:
-         - *spec* (*str*) -- the text to type
-         - *static* (boolean) --
-           if *True*, do not dynamically interpret *spec*
-           when executing this action
-         - *pause* (*float*) --
-           the time to pause between each keystroke, given
-           in seconds
-         - *autofmt* (boolean) --
-           if *True*, attempt to format the text with correct
-           spacing and capitalization.  This is done by first mimicking
-           a word recognition and then analyzing its spacing and
-           capitalization and applying the same formatting to the text.
-
+    Arguments:
+     - *spec* (*str*) -- the text to type
+     - *static* (boolean) --
+       if *True*, do not dynamically interpret *spec*
+       when executing this action
+     - *pause* (*float*) --
+       the time to pause between each keystroke, given
+       in seconds
+     - *autofmt* (boolean) --
+       if *True*, attempt to format the text with correct
+       spacing and capitalization.  This is done by first mimicking
+       a word recognition and then analyzing its spacing and
+       capitalization and applying the same formatting to the text.
     """
 
     _pause_default = 0.02
     _keyboard = Keyboard()
     _specials = {
-                 "\n":   typeables["enter"],
-                 "\t":   typeables["tab"],
+                 "\n": typeables["enter"],
+                 "\t": typeables["tab"],
                 }
 
     def __init__(self, spec=None, static=False, pause=_pause_default,
-                 autofmt=False):
+                 autofmt=False, use_hardware=False):
         self._pause = pause
         self._autofmt = autofmt
+        self._use_hardware = use_hardware
         DynStrActionBase.__init__(self, spec=spec, static=static)
 
     def _parse_spec(self, spec):
-        """ Convert the given *spec* to keyboard events. """
+        """Convert the given *spec* to keyboard events."""
+        from struct import unpack
         events = []
-        for character in spec:
-            if character in self._specials:
-                typeable = self._specials[character]
-            else:
-                try:
-                    typeable = Keyboard.get_typeable(character)
-                except ValueError as e:
-                    raise ActionError("Keyboard interface cannot type this"
-                                      " character: %r (in %r)"
-                                      % (character, spec))
-            events.extend(typeable.events(self._pause))
+        if self._use_hardware or require_hardware_emulation():
+            for character in spec:
+                if character in self._specials:
+                    typeable = self._specials[character]
+                    events.extend(typeable.events(self._pause))
+                else:
+                    try:
+                        typeable = Keyboard.get_typeable(character)
+                        events.extend(typeable.events(self._pause))
+                    except ValueError:
+                        raise ActionError("Keyboard interface cannot type this"
+                                          " character: %r (in %r)"
+                                          % (character, spec))
+        else:
+            for character in text_type(spec):
+                if character in self._specials:
+                    typeable = self._specials[character]
+                    events.extend(typeable.events(self._pause))
+                else:
+                    byte_stream = character.encode("utf-16-le")
+                    for short in unpack("<" + str(len(byte_stream) // 2) + "H",
+                                        byte_stream):
+                        try:
+                            typeable = Keyboard.get_typeable(short,
+                                                             is_text=True)
+                            events.extend(typeable.events(self._pause * 0.5))
+                        except ValueError:
+                            raise ActionError("Keyboard interface cannot type "
+                                              "this character: %r (in %r)" %
+                                              (character, spec))
         return events
 
     def _execute_events(self, events):
         """
-            Send keyboard events.
+        Send keyboard events.
 
-            If instance was initialized with *autofmt* True,
-            then this method will mimic a word recognition
-            and analyze its formatting so as to autoformat
-            the text's spacing and capitalization before
-            sending it as keyboard events.
-
+        If instance was initialized with *autofmt* True,
+        then this method will mimic a word recognition
+        and analyze its formatting so as to autoformat
+        the text's spacing and capitalization before
+        sending it as keyboard events.
         """
-
         if self._autofmt:
             # Mimic a word, select and copy it to retrieve capitalization.
             get_engine().mimic("test")

--- a/dragonfly/actions/keyboard.py
+++ b/dragonfly/actions/keyboard.py
@@ -3,25 +3,22 @@
 # (c) Copyright 2007, 2008 by Christo Butcher
 # Licensed under the LGPL.
 #
-#   Dragonfly is free software: you can redistribute it and/or modify it 
-#   under the terms of the GNU Lesser General Public License as published 
-#   by the Free Software Foundation, either version 3 of the License, or 
+#   Dragonfly is free software: you can redistribute it and/or modify it
+#   under the terms of the GNU Lesser General Public License as published
+#   by the Free Software Foundation, either version 3 of the License, or
 #   (at your option) any later version.
 #
-#   Dragonfly is distributed in the hope that it will be useful, but 
-#   WITHOUT ANY WARRANTY; without even the implied warranty of 
-#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU 
+#   Dragonfly is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 #   Lesser General Public License for more details.
 #
-#   You should have received a copy of the GNU Lesser General Public 
-#   License along with Dragonfly.  If not, see 
+#   You should have received a copy of the GNU Lesser General Public
+#   License along with Dragonfly.  If not, see
 #   <http://www.gnu.org/licenses/>.
 #
 
-"""
-This file implements a Win32 keyboard interface using sendinput.
-
-"""
+"""This file implements a Win32 keyboard interface using sendinput."""
 
 
 import time
@@ -34,68 +31,94 @@ from dragonfly.actions.sendinput import (KeyboardInput, make_input_array,
                                          send_input_array)
 
 
-#---------------------------------------------------------------------------
-# Typeable class.
-
 class Typeable(object):
+    """Container for keypress events."""
 
-    __slots__ = ("_code", "_modifiers", "_name")
+    __slots__ = ("_code", "_modifiers", "_name", "_is_text")
 
-    def __init__(self, code, modifiers=(), name=None):
+    def __init__(self, code, modifiers=(), name=None, is_text=False):
+        """Set keypress information."""
         self._code = code
         self._modifiers = modifiers
         self._name = name
+        self._is_text = is_text
 
     def __str__(self):
-        return "%s(%s)" % (self.__class__.__name__, self._name) + repr(self.events())
+        """Return information useful for debugging."""
+        return ("%s(%s)" % (self.__class__.__name__, self._name) +
+                repr(self.events()))
 
     def on_events(self, timeout=0):
-        events = [(m, True, 0) for m in self._modifiers]
-        events.append((self._code, True, timeout))
+        """Return events for pressing this key down."""
+        if self._is_text:
+            events = [(self._code, True, timeout, True)]
+        else:
+            events = [(m, True, 0) for m in self._modifiers]
+            events.append((self._code, True, timeout))
         return events
 
     def off_events(self, timeout=0):
-        events = [(m, False, 0) for m in self._modifiers]
-        events.append((self._code, False, timeout))
-        events.reverse()
+        """Return events for releasing this key."""
+        if self._is_text:
+            events = [(self._code, False, timeout, True)]
+        else:
+            events = [(m, False, 0) for m in self._modifiers]
+            events.append((self._code, False, timeout))
+            events.reverse()
         return events
 
     def events(self, timeout=0):
-        events = [(self._code, True, 0), (self._code, False, timeout)]
-        for m in self._modifiers[-1::-1]:
-            events.insert(0, (m, True, 0))
-            events.append((m, False , 0))
+        """Return events for pressing and then releasing this key."""
+        if self._is_text:
+            events = [(self._code, True, timeout, True),
+                      (self._code, False, timeout, True)]
+        else:
+            events = [(self._code, True, 0), (self._code, False, timeout)]
+            for m in self._modifiers[-1::-1]:
+                events.insert(0, (m, True, 0))
+                events.append((m, False, 0))
         return events
 
 
-#---------------------------------------------------------------------------
-# Keyboard access class.
-
 class Keyboard(object):
+    """Static class wrapper around SendInput."""
 
-    shift_code =    win32con.VK_SHIFT
-    ctrl_code =     win32con.VK_CONTROL
-    alt_code =      win32con.VK_MENU
+    shift_code = win32con.VK_SHIFT
+    ctrl_code = win32con.VK_CONTROL
+    alt_code = win32con.VK_MENU
 
     @classmethod
     def send_keyboard_events(cls, events):
         """
-            Send a sequence of keyboard events.
+        Send a sequence of keyboard events.
 
-            Positional arguments:
-            events -- a sequence of 3-tuples of the form
-                (keycode, down, timeout), where
-                keycode (int): virtual key code.
+        Positional arguments:
+        events -- a sequence of tuples of the form
+            (keycode, down, timeout), where
+                keycode (int): Win32 Virtual Key code.
                 down (boolean): True means the key will be pressed down,
                     False means the key will be released.
                 timeout (int): number of seconds to sleep after
                     the keyboard event.
-
+            or
+            (character, down, timeout, is_text), where
+                character (str): Unicode character.
+                down (boolean): True means the key will be pressed down,
+                    False means the key will be released.
+                timeout (int): number of seconds to sleep after
+                    the keyboard event.
+                is_text (boolean): True means that the keypress is targeted
+                    at a window or control that accepts Unicode text.
         """
         items = []
-        for keycode, down, timeout in events:
-            input = KeyboardInput(keycode, down)
-            items.append(input)
+        for event in events:
+            if len(event) == 3:
+                keycode, down, timeout = event
+                input_structure = KeyboardInput(keycode, down)
+            elif len(event) == 4 and event[3]:
+                character, down, timeout = event[:3]
+                input_structure = KeyboardInput(0, down, scancode=character)
+            items.append(input_structure)
             if timeout:
                 array = make_input_array(items)
                 items = []
@@ -143,7 +166,9 @@ class Keyboard(object):
         return code, modifiers
 
     @classmethod
-    def get_typeable(cls, char):
+    def get_typeable(cls, char, is_text=False):
+        if is_text:
+            return Typeable(char, is_text=True)
         code, modifiers = cls.get_keycode_and_modifiers(char)
         return Typeable(code, modifiers)
 

--- a/dragonfly/engines/backend_natlink/engine.py
+++ b/dragonfly/engines/backend_natlink/engine.py
@@ -28,6 +28,7 @@ Detecting sleep mode
  - http://blogs.msdn.com/b/tsfaware/archive/2010/03/22/detecting-sleep-mode-in-sapi.aspx
 
 """
+from locale import getpreferredencoding
 from six import text_type, binary_type
 
 from ..base        import EngineBase, EngineError, MimicFailure
@@ -41,12 +42,12 @@ import dragonfly.grammar.state as state_
 
 # ---------------------------------------------------------------------------
 
-def map_word(word, encoding="windows-1252"):
+def map_word(word, encoding=getpreferredencoding(do_setlocale=False)):
     """
     Wraps output from Dragon.
 
     This wrapper ensures text output from the engine is Unicode. It assumes the
-    encoding of byte streams is Windows-1252 by default.
+    encoding of byte streams is the current locale's preferred encoding by default.
     """
     if isinstance(word, text_type):
         return word

--- a/dragonfly/engines/backend_natlink/engine.py
+++ b/dragonfly/engines/backend_natlink/engine.py
@@ -86,7 +86,7 @@ class NatlinkEngine(EngineBase):
         """ Disconnect from natlink. """
         self.natlink.natDisconnect()
 
-    #-----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
     # Methods for working with grammars.
 
     def _load_grammar(self, grammar):
@@ -111,11 +111,8 @@ class NatlinkEngine(EngineBase):
         (compiled_grammar, rule_names) = c.compile_grammar(grammar)
         grammar._rule_names = rule_names
 
-        if (hasattr(grammar, "process_recognition_other")
-            or hasattr(grammar, "process_recognition_failure")):
-            all_results = True
-        else:
-            all_results = False
+        all_results = (hasattr(grammar, "process_recognition_other")
+                       or hasattr(grammar, "process_recognition_failure"))
         hypothesis = False
 
         attempt_connect = False

--- a/dragonfly/engines/backend_natlink/engine.py
+++ b/dragonfly/engines/backend_natlink/engine.py
@@ -28,7 +28,7 @@ Detecting sleep mode
  - http://blogs.msdn.com/b/tsfaware/archive/2010/03/22/detecting-sleep-mode-in-sapi.aspx
 
 """
-from six import text_type
+from six import text_type, binary_type
 
 from ..base        import EngineBase, EngineError, MimicFailure
 from ...error import GrammarError
@@ -39,7 +39,21 @@ from .compiler     import NatlinkCompiler
 import dragonfly.grammar.state as state_
 
 
-#---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
+
+def map_word(word, encoding="windows-1252"):
+    """
+    Wraps output from Dragon.
+
+    This wrapper ensures text output from the engine is Unicode. It assumes the
+    encoding of byte streams is Windows-1252 by default.
+    """
+    if isinstance(word, text_type):
+        return word
+    elif isinstance(word, binary_type):
+        return word.decode(encoding)
+    return word
+
 
 class NatlinkEngine(EngineBase):
     """ Speech recognition engine back-end for Natlink and DNS. """
@@ -250,6 +264,7 @@ class NatlinkEngine(EngineBase):
 
 #---------------------------------------------------------------------------
 
+
 class GrammarWrapper(object):
 
     def __init__(self, grammar, grammar_object, engine):
@@ -258,7 +273,8 @@ class GrammarWrapper(object):
         self.engine = engine
 
     def begin_callback(self, module_info):
-        executable, title, handle = module_info
+        executable, title, handle = tuple(map_word(word)
+                                          for word in module_info)
         self.grammar.process_begin(executable, title, handle)
 
     def results_callback(self, words, results):
@@ -268,7 +284,7 @@ class GrammarWrapper(object):
         if words == "other":
             func = getattr(self.grammar, "process_recognition_other", None)
             if func:
-                words = tuple(text_type(w).encode("windows-1252")
+                words = tuple(map_word(w)
                               for w in results.getWords(0))
                 func(words)
             return
@@ -281,11 +297,6 @@ class GrammarWrapper(object):
         # If the words argument was not "other" or "reject", then
         #  it is a sequence of (word, rule_id) 2-tuples.  Convert this
         #  into a tuple of unicode objects.
-        def map_word(w):
-            if isinstance(w, text_type):
-                return w
-            else:
-                return w.decode("windows-1252")
 
         words_rules = tuple((map_word(w), r) for w, r in words)
         words = tuple(w for w, r in words_rules)


### PR DESCRIPTION
The purpose of this pull request is to get the code out there and visible in case I'm dropped on my head again and I'm unable to complete it. I still need to do more refactoring, including documentation improvements. I recommend against merging it at this time, though it should be fully functional.
    
This pull request contains a mostly complete implementation of Windows SendInput Unicode keyboard functionality and a `Text` action class designed to take advantage of it, as well as documentation improvements and minor refactoring. Many of the lines changed are minor formatting changes in order to get my linter to stop pestering me.

Changes made to the SendInput code follow the process [described in the relevant Windows documentation](https://docs.microsoft.com/en-us/windows/desktop/api/winuser/ns-winuser-tagkeybdinput#remarks).  Modifier keys are silently ignored.

The `Text` class was modified around the assumption given in the current documentation that the `Text` action is not used to represent conventional keystrokes. The use of keystrokes for the special characters `'\n'` and `'\t'` remains because that behavior is abused by Caster, though that really should be changed downstream. It also includes basic user configuration support that could be spun out into its own submodule. The user configuration is primarily used to identify certain Windows programs that require 'hardware' keyboard input, such as remote desktop and virtualization software.

None of these changes have been tested against Aenea, though they should otherwise be backwards compatible.